### PR TITLE
Only require unittest2 on python < 2.7

### DIFF
--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -1,2 +1,1 @@
 -r deps/mock.txt
-unittest2>=0.5.1

--- a/requirements/py26.txt
+++ b/requirements/py26.txt
@@ -1,1 +1,2 @@
 importlib
+unittest2>=0.5.1


### PR DESCRIPTION
See also: https://github.com/celery/case/issues/1
